### PR TITLE
Upgrade to 8.15.3

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -4,6 +4,6 @@
 # See: https://github.com/madler/zlib/pull/843#issuecomment-2130408505
 CVE-2023-45853
 
-# This CVE is contained in the upstream debian:12-slim base image.
+# This wget CVE is contained in the upstream debian:12-slim base image.
 # In this Dogu, all args to wget are static and not modifiable by the user.
 CVE-2024-38428

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,5 @@
+# This zlib1g CVE is falsely detected. It is not present in the Debian 12
+# package and thus ignored as "not affected". The trivy project however
+# interprets this as ignored as "wont fix" and causes a detection.
+# See: https://github.com/madler/zlib/pull/843#issuecomment-2130408505
+CVE-2023-45853

--- a/.trivyignore
+++ b/.trivyignore
@@ -3,3 +3,7 @@
 # interprets this as ignored as "wont fix" and causes a detection.
 # See: https://github.com/madler/zlib/pull/843#issuecomment-2130408505
 CVE-2023-45853
+
+# This CVE is contained in the upstream debian:12-slim base image.
+# In this Dogu, all args to wget are static and not modifiable by the user.
+CVE-2024-38428

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [#14] Upgrade Gotenberg to 8.15.3
 - [#12] Update Makefiles to 9.5.0
+- Upgrade ces-build-lib to 4.0.1
+- Upgrade dogu-build-lib to 3.0.0
 
 ## [v8.12.0-1] - 2024-10-22
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,11 @@ FROM registry.cloudogu.com/official/base:3.21.0-1 as doguctlBinary
 FROM gotenberg/gotenberg:8.15.3
 
 USER root
+# hadolint ignore=DL3005
 RUN apt-get -y update && apt-get -y dist-upgrade && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 USER gotenberg
 
+# hadolint ignore=DL3048
 LABEL NAME="official/gotenberg" \
       VERSION="8.15.3-1" \
       maintainer="SCM Team <scm-team@cloudogu.com>"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # keep variables beyond the single build stages, see https://stackoverflow.com/a/53682110/12529534
 
-FROM registry.cloudogu.com/official/base:3.20.2-1 as doguctlBinary
+FROM registry.cloudogu.com/official/base:3.21.0-1 as doguctlBinary
 
 FROM gotenberg/gotenberg:8.15.3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@
 
 FROM registry.cloudogu.com/official/base:3.20.2-1 as doguctlBinary
 
-FROM gotenberg/gotenberg:8.12.0
+FROM gotenberg/gotenberg:8.15.3
 
 USER root
 RUN apt-get -y update && apt-get -y dist-upgrade && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 USER gotenberg
 
 LABEL NAME="official/gotenberg" \
-      VERSION="8.12.0-1" \
+      VERSION="8.15.3-1" \
       maintainer="SCM Team <scm-team@cloudogu.com>"
 
 COPY resources /

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ USER gotenberg
 
 # hadolint ignore=DL3048
 LABEL NAME="official/gotenberg" \
-      VERSION="8.15.3-1" \
+      VERSION="8.12.0-1" \
       maintainer="SCM Team <scm-team@cloudogu.com>"
 
 COPY resources /

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,6 +29,14 @@ node('vagrant') {
         stage('Lint') {
             lintDockerfile()
             shellCheck("resources/startup.sh")
+
+            if (env.CHANGE_TARGET) {
+                echo 'This is a pull request; checking changelog...'
+                String newChanges = changelog.changesForVersion('Unreleased')
+                if (!newChanges || newChanges.allWhitespace) {
+                    unstable('CHANGELOG.md should contain new change entries in the `[Unreleased]` section but none were found.')
+                }
+            }
         }
 
         try {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,6 +37,9 @@ node('vagrant') {
                     unstable('CHANGELOG.md should contain new change entries in the `[Unreleased]` section but none were found.')
                 }
             }
+
+            Markdown markdown = new Markdown(this)
+            markdown.check()
         }
 
         try {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,8 +21,8 @@ node('vagrant') {
                 disableConcurrentBuilds(),
                 // Parameter to activate dogu upgrade test on demand
                 parameters([
-                        choice(name: 'TrivySeverityLevels', choices: [TrivySeverityLevel.CRITICAL, TrivySeverityLevel.HIGH_AND_ABOVE, TrivySeverityLevel.MEDIUM_AND_ABOVE, TrivySeverityLevel.ALL], description: 'The levels to scan with trivy'),
-                        choice(name: 'TrivyStrategy', choices: [TrivyScanStrategy.UNSTABLE, TrivyScanStrategy.FAIL, TrivyScanStrategy.IGNORE], description: 'Define whether the build should be unstable, fail or whether the error should be ignored if any vulnerability was found.'),
+                        choice(name: 'TrivySeverityLevels', choices: [TrivySeverityLevel.CRITICAL, TrivySeverityLevel.HIGH_AND_ABOVE, TrivySeverityLevel.MEDIUM_AND_ABOVE, TrivySeverityLevel.ALL], description: 'The levels to scan with trivy', defaultValue: TrivySeverityLevel.CRITICAL),
+                        choice(name: 'TrivyStrategy', choices: [TrivyScanStrategy.UNSTABLE, TrivyScanStrategy.FAIL, TrivyScanStrategy.IGNORE], description: 'Define whether the build should be unstable, fail or whether the error should be ignored if any vulnerability was found.', defaultValue: TrivyScanStrategy.UNSTABLE),
                 ])
         ])
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,12 @@ node('vagrant') {
                 // Keep only the last x builds to preserve space
                 buildDiscarder(logRotator(numToKeepStr: '10')),
                 // Don't run concurrent builds for a branch, because they use the same workspace directory
-                disableConcurrentBuilds()
+                disableConcurrentBuilds(),
+                // Parameter to activate dogu upgrade test on demand
+                parameters([
+                        choice(name: 'TrivySeverityLevels', choices: [TrivySeverityLevel.CRITICAL, TrivySeverityLevel.HIGH_AND_ABOVE, TrivySeverityLevel.MEDIUM_AND_ABOVE, TrivySeverityLevel.ALL], description: 'The levels to scan with trivy'),
+                        choice(name: 'TrivyStrategy', choices: [TrivyScanStrategy.UNSTABLE, TrivyScanStrategy.FAIL, TrivyScanStrategy.IGNORE], description: 'Define whether the build should be unstable, fail or whether the error should be ignored if any vulnerability was found.'),
+                ])
         ])
 
         EcoSystem ecoSystem = new EcoSystem(this, "gcloud-ces-operations-internal-packer", "jenkins-gcloud-ces-operations-internal")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library(['github.com/cloudogu/ces-build-lib@1.64.2', 'github.com/cloudogu/dogu-build-lib@v2.1.0'])
+@Library(['github.com/cloudogu/ces-build-lib@4.0.1', 'github.com/cloudogu/dogu-build-lib@v3.0.0'])
 import com.cloudogu.ces.cesbuildlib.*
 import com.cloudogu.ces.dogubuildlib.*
 

--- a/docs/development/visual_tests_de.md
+++ b/docs/development/visual_tests_de.md
@@ -11,6 +11,7 @@ Es muss sichergestellt werden, dass die folgenden Dogus installiert sind:
 - `official/cas`
 - `official/nginx`
 - `official/postfix`
+- `official/usermgt`
 
 ## 2. Installation Gotenberg Dogu
 


### PR DESCRIPTION
This change updates Gotenberg to v8.15.3.

It will also update:
 - ces-build-lib to 4.0.1
 - dogu-build-lib to 3.0.0
 - doguctl (extracted from official/base:3.21.0-1)

And add:
 - Trivy scanning
 - Changelog linting
 - Markdown linting