### PR TITLE
[51] Fix CVE-2025-68121

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [#51] Update Gotenberg to v8.27.0
+- [#51] Update base image to v3.23.3-4
+### Security
+- [#51] CVE fixed: [cve-2025-68121](https://avd.aquasec.com/nvd/2025/cve-2025-68121/)
 
 ## [v8.25.1-3] - 2026-01-30
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # keep variables beyond the single build stages, see https://stackoverflow.com/a/53682110/12529534
 
-FROM registry.cloudogu.com/official/base:3.23.0-1 AS doguctlbinary
+FROM registry.cloudogu.com/official/base:3.23.3-4 AS doguctlbinary
 
-FROM gotenberg/gotenberg:8.25.1
+FROM gotenberg/gotenberg:8.27.0
 
 USER root
 # hadolint ignore=DL3005

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-MAKEFILES_VERSION=10.5.0
+MAKEFILES_VERSION=10.6.0
 
 .DEFAULT_GOAL:=dogu-release
 
@@ -8,3 +8,4 @@ include build/make/release.mk
 include build/make/clean.mk
 include build/make/k8s-dogu.mk
 include build/make/prerelease.mk
+include build/make/trivyscan.mk

--- a/build/make/k8s.mk
+++ b/build/make/k8s.mk
@@ -35,12 +35,16 @@ K3S_CLUSTER_FQDN?=k3ces.local
 K3S_LOCAL_REGISTRY_PORT?=30099
 
 # The URL of the container-registry to use. Defaults to the registry of the local-cluster.
-# If RUNTIME_ENV is "remote" it is "registry.cloudogu.com/testing"
+# If RUNTIME_ENV is "remote" it is "registry.cloudogu.com/testing", if ENVIRONMENT is "ci" it is "registry.cloudogu.com/ci"
+# if run on ci (jenkins) the images must be pushed to a separate namespace in order to free space every night after the build.
 CES_REGISTRY_HOST?=${K3S_CLUSTER_FQDN}:${K3S_LOCAL_REGISTRY_PORT}
 CES_REGISTRY_NAMESPACE ?=
 ifeq (${RUNTIME_ENV}, remote)
 	CES_REGISTRY_HOST=registry.cloudogu.com
 	CES_REGISTRY_NAMESPACE=/testing
+	ifeq ($(ENVIRONMENT), ci)
+		CES_REGISTRY_NAMESPACE=/ci
+	endif
 endif
 $(info CES_REGISTRY_HOST=$(CES_REGISTRY_HOST))
 


### PR DESCRIPTION
 - Update Gotenberg to v8.27.0
 - Update base image to v3.23.3-4